### PR TITLE
Fix promise resolve typo in auth

### DIFF
--- a/frontend/lib/auth.js
+++ b/frontend/lib/auth.js
@@ -5,7 +5,7 @@ const API_URL = process.env.NEXT_PUBLIC_API_URL || "https://localhost:1337"
 
 // 新しいユーザを登録
 export const registerUser = async (username, email, password) => {
-    return new Promise((resolove, reject) => {
+    return new Promise((resolve, reject) => {
         axios
             .post(`${API_URL}/auth/local/register`, {
                 username,
@@ -14,7 +14,7 @@ export const registerUser = async (username, email, password) => {
             })
             .then((res) => {
                 Cookie.set("token", res.data.jwt, { expires: 7 });
-                resolove(res);
+                resolve(res);
                 window.location.href = "/";
             })
             .catch((err) => {


### PR DESCRIPTION
## Summary
- fix `registerUser` promise resolution by replacing `resolove` with `resolve`

## Testing
- `npm test --prefix frontend` *(fails: Missing script)*